### PR TITLE
feat(widget): support CSV and Excel attachments

### DIFF
--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @opencx/widget-core
 
+## 4.0.54
+
+### Patch Changes
+
+- support for csv and excel attachments
+
 ## 4.0.53
 
 ### Patch Changes

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@opencx/widget-core",
   "private": false,
-  "version": "4.0.53",
+  "version": "4.0.54",
   "type": "module",
   "repository": {
     "type": "git",

--- a/packages/embed/CHANGELOG.md
+++ b/packages/embed/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @opencx/widget
 
+## 4.0.54
+
+### Patch Changes
+
+- support for csv and excel attachments
+
 ## 4.0.53
 
 ### Patch Changes

--- a/packages/embed/package.json
+++ b/packages/embed/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@opencx/widget",
   "private": false,
-  "version": "4.0.53",
+  "version": "4.0.54",
   "type": "module",
   "repository": {
     "type": "git",

--- a/packages/react-headless/CHANGELOG.md
+++ b/packages/react-headless/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @opencx/widget-react-headless
 
+## 4.0.54
+
+### Patch Changes
+
+- support for csv and excel attachments
+- Updated dependencies
+  - @opencx/widget-core@4.0.54
+
 ## 4.0.53
 
 ### Patch Changes

--- a/packages/react-headless/package.json
+++ b/packages/react-headless/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@opencx/widget-react-headless",
   "private": false,
-  "version": "4.0.53",
+  "version": "4.0.54",
   "type": "module",
   "repository": {
     "type": "git",

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,14 @@
 # @opencx/widget-react
 
+## 4.0.54
+
+### Patch Changes
+
+- support for csv and excel attachments
+- Updated dependencies
+  - @opencx/widget-core@4.0.54
+  - @opencx/widget-react-headless@4.0.54
+
 ## 4.0.53
 
 ### Patch Changes

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@opencx/widget-react",
   "private": false,
-  "version": "4.0.53",
+  "version": "4.0.54",
   "type": "module",
   "repository": {
     "type": "git",

--- a/packages/react/src/components/AttachmentPreview.tsx
+++ b/packages/react/src/components/AttachmentPreview.tsx
@@ -1,6 +1,7 @@
 import type { MessageAttachmentType } from '@opencx/widget-core';
-import { FileText } from 'lucide-react';
+import { FileSpreadsheet, FileText } from 'lucide-react';
 import React from 'react';
+import { getSpreadsheet } from '../utils/attachment-kind';
 import { cn } from './lib/utils/cn';
 import { Wobble } from './lib/wobble';
 import { Dialoger, DialogerContent } from './Dialoger';
@@ -9,6 +10,62 @@ import { ZoomableImage } from './ZoomableImage';
 type Props = {
   attachment: MessageAttachmentType;
 };
+
+// Downloadable file chip (icon + name + "size · label"), used for PDFs and
+// spreadsheets that render as a card rather than inline.
+function FileCard({
+  url,
+  name,
+  size,
+  icon,
+  label,
+}: {
+  url: string;
+  name: string;
+  size: number;
+  icon: React.ReactNode;
+  label: string;
+}) {
+  return (
+    <Wobble>
+      <a
+        href={url}
+        target="_blank"
+        rel="noopener noreferrer"
+        className={cn(
+          'block size-fit max-w-[min(100%,16rem)] shrink-0 rounded-2xl border',
+          'bg-background/80 transition-colors hover:bg-accent/60',
+          'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2',
+        )}
+      >
+        <div className="flex items-center gap-3 p-3 min-w-0">
+          <div
+            className={cn(
+              'flex size-10 shrink-0 items-center justify-center rounded-xl',
+              'bg-secondary text-muted-foreground',
+            )}
+            aria-hidden
+          >
+            {icon}
+          </div>
+          <div className="min-w-0 flex-1 flex flex-col gap-0.5 text-left">
+            <span
+              className={cn(
+                'text-xs font-medium text-foreground line-clamp-1',
+                'break-words [word-break:break-word]', // `[word-break:break-word]` is deprecated but works in the browser, while `break-words` which is `[overflow-wrap: break-word]` does not work
+              )}
+            >
+              {name}
+            </span>
+            <span className="text-xs text-muted-foreground tabular-nums">
+              {(size / 1024).toFixed(2)} KB · {label}
+            </span>
+          </div>
+        </div>
+      </a>
+    </Wobble>
+  );
+}
 
 export function AttachmentPreview({ attachment }: Props) {
   const { name, size, type, url } = attachment;
@@ -69,43 +126,26 @@ export function AttachmentPreview({ attachment }: Props) {
 
   if (isPdf) {
     return (
-      <Wobble>
-        <a
-          href={url}
-          target="_blank"
-          rel="noopener noreferrer"
-          className={cn(
-            'block size-fit max-w-[min(100%,16rem)] shrink-0 rounded-2xl border',
-            'bg-background/80 transition-colors hover:bg-accent/60',
-            'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2',
-          )}
-        >
-          <div className="flex items-center gap-3 p-3 min-w-0">
-            <div
-              className={cn(
-                'flex size-10 shrink-0 items-center justify-center rounded-xl',
-                'bg-secondary text-muted-foreground',
-              )}
-              aria-hidden
-            >
-              <FileText className="size-5" strokeWidth={1.75} />
-            </div>
-            <div className="min-w-0 flex-1 flex flex-col gap-0.5 text-left">
-              <span
-                className={cn(
-                  'text-xs font-medium text-foreground line-clamp-1',
-                  'break-words [word-break:break-word]', // `[word-break:break-word]` is deprecated but works in the browser, while `break-words` which is `[overflow-wrap: break-word]` does not work
-                )}
-              >
-                {name}
-              </span>
-              <span className="text-xs text-muted-foreground tabular-nums">
-                {(size / 1024).toFixed(2)} KB · PDF
-              </span>
-            </div>
-          </div>
-        </a>
-      </Wobble>
+      <FileCard
+        url={url}
+        name={name}
+        size={size}
+        icon={<FileText className="size-5" strokeWidth={1.75} />}
+        label="PDF"
+      />
+    );
+  }
+
+  const spreadsheet = getSpreadsheet({ type, name });
+  if (spreadsheet) {
+    return (
+      <FileCard
+        url={url}
+        name={name}
+        size={size}
+        icon={<FileSpreadsheet className="size-5" strokeWidth={1.75} />}
+        label={spreadsheet.label}
+      />
     );
   }
 

--- a/packages/react/src/screens/chat/ChatFooter.tsx
+++ b/packages/react/src/screens/chat/ChatFooter.tsx
@@ -18,6 +18,7 @@ import {
   CircleDashed,
   FileAudio2Icon,
   FileIcon,
+  FileSpreadsheet,
   FileText,
   FileVideo2Icon,
   Loader2,
@@ -36,6 +37,10 @@ import { Tooltippy } from '../../components/lib/tooltip';
 import { cn } from '../../components/lib/utils/cn';
 import { useIsSmallScreen } from '../../hooks/useIsSmallScreen';
 import { useTranslation } from '../../hooks/useTranslation';
+import {
+  getSpreadsheet,
+  SPREADSHEET_ACCEPT,
+} from '../../utils/attachment-kind';
 import { dc } from '../../utils/data-component';
 import { ChatFooterItems } from './ChatFooterItems';
 
@@ -92,6 +97,9 @@ function FileDisplay({
     }
     if (file.type === 'application/pdf') {
       return <FileText className="size-4 text-muted-foreground" />;
+    }
+    if (getSpreadsheet({ type: file.type, name: file.name })) {
+      return <FileSpreadsheet className="size-4 text-muted-foreground" />;
     }
     return <FileIcon className="size-4 text-muted-foreground" />;
   };
@@ -216,6 +224,7 @@ function ChatInput() {
           'text/*': ['.txt'],
           'image/*': ['.png', '.jpg', '.jpeg', '.gif'],
           'application/pdf': ['.pdf'],
+          ...SPREADSHEET_ACCEPT,
         }
       : {
           'image/png': ['.png'],
@@ -223,6 +232,7 @@ function ChatInput() {
           'image/gif': ['.gif'],
           'image/webp': ['.webp'],
           'application/pdf': ['.pdf'],
+          ...SPREADSHEET_ACCEPT,
         },
   });
 
@@ -305,7 +315,7 @@ function ChatInput() {
           <Tooltippy
             side="top"
             align="start"
-            content="attach images or PDF (maximum size 5mb)"
+            content="attach images, PDFs, or spreadsheets (maximum size 5mb)"
           >
             <Button
               onClick={dropzone__openFileSelect}

--- a/packages/react/src/utils/__tests__/attachment-kind.spec.ts
+++ b/packages/react/src/utils/__tests__/attachment-kind.spec.ts
@@ -1,0 +1,144 @@
+import { getSpreadsheet, SPREADSHEET_ACCEPT } from '../attachment-kind';
+
+describe('getSpreadsheet', () => {
+  describe('by MIME type', () => {
+    it('classifies text/csv as csv', () => {
+      expect(getSpreadsheet({ type: 'text/csv', name: 'export' })?.kind).toBe(
+        'csv',
+      );
+    });
+
+    it('classifies application/csv as csv', () => {
+      expect(
+        getSpreadsheet({ type: 'application/csv', name: 'export' })?.kind,
+      ).toBe('csv');
+    });
+
+    it('classifies application/vnd.ms-excel as excel', () => {
+      expect(
+        getSpreadsheet({ type: 'application/vnd.ms-excel', name: 'book' })
+          ?.kind,
+      ).toBe('excel');
+    });
+
+    it('classifies the xlsx OpenXML type as excel', () => {
+      expect(
+        getSpreadsheet({
+          type: 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+          name: 'book',
+        })?.kind,
+      ).toBe('excel');
+    });
+
+    it('ignores MIME parameters and casing', () => {
+      expect(
+        getSpreadsheet({ type: 'TEXT/CSV; charset=utf-8', name: 'x' })?.kind,
+      ).toBe('csv');
+    });
+  });
+
+  describe('by file extension (extension wins over MIME)', () => {
+    it('classifies a .csv name as csv even when type is octet-stream', () => {
+      expect(
+        getSpreadsheet({
+          type: 'application/octet-stream',
+          name: 'report.csv',
+        })?.kind,
+      ).toBe('csv');
+    });
+
+    it('classifies a .xls name as excel', () => {
+      expect(getSpreadsheet({ type: '', name: 'legacy.xls' })?.kind).toBe(
+        'excel',
+      );
+    });
+
+    it('classifies a .xlsx name as excel', () => {
+      expect(getSpreadsheet({ type: '', name: 'modern.xlsx' })?.kind).toBe(
+        'excel',
+      );
+    });
+
+    it('disambiguates a .csv reported with the .xls MIME type as csv', () => {
+      // Browsers sometimes report a .csv as application/vnd.ms-excel — the
+      // extension must take precedence so the label reads "CSV", not "Excel".
+      expect(
+        getSpreadsheet({
+          type: 'application/vnd.ms-excel',
+          name: 'data.csv',
+        })?.kind,
+      ).toBe('csv');
+    });
+
+    it('is case-insensitive on the extension', () => {
+      expect(getSpreadsheet({ type: '', name: 'REPORT.CSV' })?.kind).toBe(
+        'csv',
+      );
+      expect(getSpreadsheet({ type: '', name: 'Book.XLSX' })?.kind).toBe(
+        'excel',
+      );
+    });
+  });
+
+  describe('descriptor exposes a human label', () => {
+    it('labels csv as CSV', () => {
+      expect(getSpreadsheet({ type: 'text/csv', name: 'x.csv' })?.label).toBe(
+        'CSV',
+      );
+    });
+
+    it('labels excel as Excel', () => {
+      expect(getSpreadsheet({ type: '', name: 'x.xlsx' })?.label).toBe('Excel');
+    });
+  });
+
+  describe('non-spreadsheets return null', () => {
+    it('returns null for images', () => {
+      expect(
+        getSpreadsheet({ type: 'image/png', name: 'photo.png' }),
+      ).toBeNull();
+    });
+
+    it('returns null for PDFs', () => {
+      expect(
+        getSpreadsheet({ type: 'application/pdf', name: 'doc.pdf' }),
+      ).toBeNull();
+    });
+
+    it('returns null for plain text', () => {
+      expect(
+        getSpreadsheet({ type: 'text/plain', name: 'notes.txt' }),
+      ).toBeNull();
+    });
+
+    it('returns null for an unknown type with no extension', () => {
+      expect(
+        getSpreadsheet({ type: 'application/octet-stream', name: 'blob' }),
+      ).toBeNull();
+    });
+
+    it('returns null for empty type and empty name', () => {
+      expect(getSpreadsheet({ type: '', name: '' })).toBeNull();
+    });
+  });
+});
+
+describe('SPREADSHEET_ACCEPT (react-dropzone accept map)', () => {
+  it('maps every spreadsheet MIME type to dotted extensions', () => {
+    expect(SPREADSHEET_ACCEPT).toEqual({
+      'text/csv': ['.csv'],
+      'application/csv': ['.csv'],
+      'application/vnd.ms-excel': ['.xls', '.xlsx'],
+      'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet': [
+        '.xls',
+        '.xlsx',
+      ],
+    });
+  });
+
+  it('uses dotted extensions as react-dropzone requires', () => {
+    for (const exts of Object.values(SPREADSHEET_ACCEPT)) {
+      for (const ext of exts) expect(ext.startsWith('.')).toBe(true);
+    }
+  });
+});

--- a/packages/react/src/utils/attachment-kind.ts
+++ b/packages/react/src/utils/attachment-kind.ts
@@ -1,0 +1,54 @@
+export type SpreadsheetKind = 'csv' | 'excel';
+
+export type Spreadsheet = {
+  kind: SpreadsheetKind;
+  label: string;
+  mimes: string[];
+  extensions: string[];
+};
+
+// Browsers report spreadsheets inconsistently (a .csv can arrive as
+// application/vnd.ms-excel or application/octet-stream), so match on file
+// extension before MIME.
+const SPREADSHEETS: Spreadsheet[] = [
+  {
+    kind: 'csv',
+    label: 'CSV',
+    mimes: ['text/csv', 'application/csv'],
+    extensions: ['csv'],
+  },
+  {
+    kind: 'excel',
+    label: 'Excel',
+    mimes: [
+      'application/vnd.ms-excel',
+      'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+    ],
+    extensions: ['xls', 'xlsx'],
+  },
+];
+
+// react-dropzone accept map (MIME → dotted extensions), derived so the
+// accepted types stay defined in one place.
+export const SPREADSHEET_ACCEPT: Record<string, string[]> = Object.fromEntries(
+  SPREADSHEETS.flatMap((sheet) =>
+    sheet.mimes.map((mime) => [mime, sheet.extensions.map((ext) => `.${ext}`)]),
+  ),
+);
+
+export function getSpreadsheet({
+  type,
+  name,
+}: {
+  type: string;
+  name: string;
+}): Spreadsheet | null {
+  const ext = name.split('.').pop()?.toLowerCase() ?? '';
+  const mime = type.toLowerCase().split(';')[0]?.trim() ?? '';
+  // Extension wins over MIME, so check every extension before any MIME.
+  return (
+    SPREADSHEETS.find((sheet) => ext && sheet.extensions.includes(ext)) ??
+    SPREADSHEETS.find((sheet) => mime && sheet.mimes.includes(mime)) ??
+    null
+  );
+}


### PR DESCRIPTION
Add CSV/Excel (`.csv`, `.xls`, `.xlsx`) attachment support to the widget composer.

## Changes
- Allow spreadsheets in the dropzone `accept` list — in both the AI and handed-off states, alongside images and PDFs.
- Composer thumbnail shows a `FileSpreadsheet` icon; the sent message renders a labeled file card ("CSV"/"Excel") instead of a bare link.
- New `attachment-kind` util: single source of truth for spreadsheet MIME/extension matching, labels, and the derived dropzone `accept` map.
- Extract a shared `FileCard` for the PDF and spreadsheet message cards.

i made sure that the other formats were selectable (default) plus the CSV file (new behaviour)
<img width="454" height="664" alt="image" src="https://github.com/user-attachments/assets/148c4dae-571d-440c-a1b4-4d56d50240be" />



## Tests
`attachment-kind.spec.ts` — 19 cases covering MIME and extension matching, extension-wins-over-MIME disambiguation, octet-stream fallback, case-insensitivity, non-spreadsheets, and the derived accept map.